### PR TITLE
Added support for scanning multiple directories

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -36,6 +36,13 @@ extend the DefaultFilter.
 
 === Other Options
 
+Available with Version 0.2.5:
+
+You may use the Annotation @Directories to search for test classes in multiple directories.
+
+  @Directories({"bin", "target/classes"})
+  @Directories({"src/test/java", "src/test/generated"})
+
 Available with Version 0.2.3:
 
 You may use the Annotation @Sort to sort the tests by TestName or Randomize them.
@@ -73,7 +80,7 @@ or include it in Maven (from Maven Central Repository):
     <dependency>
         <groupId>com.github.cschoell</groupId>
         <artifactId>junit-dynamicsuite</artifactId>
-        <version>0.2.2</version>
+        <version>0.2.5</version>
         <scope>test</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,8 @@
     <commons-lang3.version>3.3.2</commons-lang3.version>
     <commons-io.version>2.4</commons-io.version>
     <mockito-all.version>1.9.5</mockito-all.version>
+	<timestamp>${maven.build.timestamp}</timestamp>
+	<maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
   </properties>
 
   <dependencies>
@@ -87,6 +89,27 @@
       </plugin>
 
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>1.7</version>
+        <executions>
+          <execution>
+            <id>regex-property</id>
+            <goals>
+              <goal>regex-property</goal>
+            </goals>
+            <configuration>
+              <name>projectBaseVersion</name>
+              <value>${project.version}</value>
+              <regex>^(.*?)(-SNAPSHOT)?$</regex>
+              <replacement>$1</replacement>
+              <failIfNoMatch>true</failIfNoMatch>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>2.4</version>
@@ -96,13 +119,11 @@
               <Bundle-ManifestVersion>2</Bundle-ManifestVersion>
               <Bundle-Name>JUnit Dynamicsuite</Bundle-Name>
               <Bundle-SymbolicName>org.junit.extensions.dynamicsuite</Bundle-SymbolicName>
-              <Bundle-Version>${project.version}.qualifier</Bundle-Version>
+              <Bundle-Version>${projectBaseVersion}.${timestamp}</Bundle-Version>
               <Bundle-Vendor>Christof Schoell</Bundle-Vendor>
               <Bundle-RequiredExecutionEnvironment>JavaSE-1.6</Bundle-RequiredExecutionEnvironment>
               <Require-Bundle>org.junit;bundle-version="${junit.version}", org.apache.commons.lang3;bundle-version="${commons-lang3.version}"</Require-Bundle>
-              <Export-Package>org.junit.extensions.dynamicsuite, org.junit.extensions.dynamicsuite.suite,
-                org.junit.extensions.dynamicsuite.filter, org.junit.extensions.dynamicsuite.sort
-              </Export-Package>
+              <Export-Package>org.junit.extensions.dynamicsuite, org.junit.extensions.dynamicsuite.suite, org.junit.extensions.dynamicsuite.filter, org.junit.extensions.dynamicsuite.sort</Export-Package>
             </manifestEntries>
           </archive>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.github.cschoell</groupId>
   <artifactId>junit-dynamicsuite</artifactId>
-  <version>0.2.4-SNAPSHOT</version>
+  <version>0.2.5-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <scm>
@@ -105,6 +105,19 @@
               </Export-Package>
             </manifestEntries>
           </archive>
+        </configuration>
+      </plugin>
+      
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.16</version>
+    
+        <configuration>
+          <includes>
+              <include>**/*Test.java</include>
+              <include>**/*Suite.java</include>
+          </includes>
         </configuration>
       </plugin>
     </plugins>

--- a/src/main/java/org/junit/extensions/dynamicsuite/Directories.java
+++ b/src/main/java/org/junit/extensions/dynamicsuite/Directories.java
@@ -1,0 +1,29 @@
+package org.junit.extensions.dynamicsuite;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Copyright 2014 Christof Schoell
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+public @interface Directories {
+    public String[] value() default { "target/test-classes" };
+}

--- a/src/main/java/org/junit/extensions/dynamicsuite/engine/ScannerFactory.java
+++ b/src/main/java/org/junit/extensions/dynamicsuite/engine/ScannerFactory.java
@@ -1,6 +1,7 @@
 package org.junit.extensions.dynamicsuite.engine;
 
 import org.junit.extensions.dynamicsuite.ClassPath;
+import org.junit.extensions.dynamicsuite.Directories;
 import org.junit.extensions.dynamicsuite.Directory;
 
 import java.io.File;
@@ -44,9 +45,20 @@ public class ScannerFactory {
 
         if (annotation != null) {
             return new DirectoryScanner(new File(annotation.value()));
+        } else {
+            Directories dirs = (Directories) filterAnnotatedClass.getAnnotation(Directories.class);
+            if (dirs != null) {
+                File[] paths = new File[dirs.value().length];
+                for (int i = 0; i < dirs.value().length; i++) {
+                    paths[i] = new File(dirs.value()[i]);
+                }
+                return new DirectoryScanner(paths);
+            }
         }
+
         return null;
     }
+
     private ClassScanner createClassPathScanner(Class filterAnnotatedClass) throws InstantiationException, IllegalAccessException {
         ClassPath annotation = (ClassPath) filterAnnotatedClass.getAnnotation(ClassPath.class);
 

--- a/src/test/java/org/junit/extensions/dynamicsuite/MultiDirSuite.java
+++ b/src/test/java/org/junit/extensions/dynamicsuite/MultiDirSuite.java
@@ -1,0 +1,38 @@
+package org.junit.extensions.dynamicsuite;
+
+import org.junit.extensions.dynamicsuite.suite.DynamicSuite;
+import org.junit.runner.RunWith;
+
+/**
+ * Copyright 2014 Christof Schoell
+ * <p/>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@RunWith(DynamicSuite.class)
+@Filter(MultiDirSuite.class)
+@Directories({"target/test-classes", "src/test/java"})
+@Sort(SortBy.TESTNAME)
+public class MultiDirSuite implements TestClassFilter {
+
+
+    @Override
+    public boolean include(String className) {
+        return className.endsWith("ITCase");
+    }
+
+
+    @Override
+    public boolean include(Class cls) {
+        return cls.getAnnotation(Slow.class) == null;
+    }
+}


### PR DESCRIPTION
Hi,

I've added support for scanning multiple directories, configurable via an annotation `@Directories` taking a string array value.
I'm needing this for projects that are (a) built both with eclipse (outputDir = `bin/`) and maven (outputDir = `target/classes`) and (b) contain both "normal" (srcDir = `src/`) and generated code (srcDir = `src-gen/` or `xtend-gen/`)